### PR TITLE
Fixes #1761

### DIFF
--- a/apis/onlyfans/classes/create_post.py
+++ b/apis/onlyfans/classes/create_post.py
@@ -10,7 +10,7 @@ class create_post:
         self.postedAt: str = option.get("postedAt")
         self.postedAtPrecise: str = option.get("postedAtPrecise")
         self.expiredAt: Any = option.get("expiredAt")
-        self.author = create_user.create_user(option["author"])
+        self.author = create_user.create_user(option.get("author",{}))
         self.text: str = option.get("text")
         self.rawText: str = option.get("rawText")
         self.lockedText: bool = option.get("lockedText")


### PR DESCRIPTION
Certain model failed to retrieve throwing a KeyError.

 Traced the bug to this line. Downstream the author is accessed via a dict's `get` method, so I defaulted to an empty dict. 