### PR TITLE
Make psutil dependency not required

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,6 @@ beautifulsoup4
 urllib3
 win32-setctime
 python-socks[asyncio]
-psutil
 python-dateutil
 lxml
 mergedeep


### PR DESCRIPTION
The module was used only to obtain the free space on disk but the same behavior can be reproduced in pure Python. Making the module not required helps the portability of the code as it not requires building or downloading prebuilt versions of the psutil module which may not available for some Python versions or systems.

As the time of this writing the module psutil is not available as a precompiled package for Python 3.10.

The code was tested on both Windows and Linux.