### PR TITLE
Added timeout on request.get() for ensuring that if a recipient serve…

### DIFF
--- a/apis/api_helper.py
+++ b/apis/api_helper.py
@@ -96,7 +96,8 @@ class session_manager:
         self.headers = headers
         self.proxies: list[str] = proxies
         dr_link = global_settings["dynamic_rules_link"]
-        dynamic_rules = requests.get(dr_link).json()  # type: ignore
+        # OpenRefactory Warning: The 'requests.get' method does not use any 'timeout' threshold which may cause program to hang indefinitely.
+        dynamic_rules = requests.get(dr_link, timeout=100).json()  # type: ignore
         self.dynamic_rules = dynamic_rules
         self.auth = auth
 

--- a/updater.py
+++ b/updater.py
@@ -12,8 +12,9 @@ import time
 # response_json = response.json()
 # commit_id = response_json["commit"]["sha"]
 # downloaded = requests.get(f"https://github.com/DIGITALCRIMINAL/OnlyFans/archive/{commit_id}.zip")
+# OpenRefactory Warning: The 'requests.get' method does not use any 'timeout' threshold which may cause program to hang indefinitely.
 downloaded = requests.get(
-    f"https://github.com/DIGITALCRIMINAL/OnlyFans/archive/refs/heads/master.zip"
+    f"https://github.com/DIGITALCRIMINAL/OnlyFans/archive/refs/heads/master.zip", timeout=100
 )
 content = io.BytesIO(downloaded.content)
 # Zip download for manual extraction


### PR DESCRIPTION
We have detected this issue in the `master` branch of `OnlyFans` project on the version with commit hash `d1a5f7`. This is an instance of an api usage issue.

**Fixes for api usage issue:**
In file: `api_helper.py`, method `__init__` a request is made without a timeout parameter. If the recipient server is unavailable to service the request, [application making the request may stall indefinitely. ](https://docs.python-requests.org/en/master/user/advanced/#timeouts)iCR suggested that a timeout value should be specified.
Also In file: `updater.py`, a request is made without a timeout parameter.

This issue was detected by our **OpenRefactory's Intelligent Code Repair (iCR)**. We are running **iCR** on libraries in the `PyPI` repository to identify issues and fix them. You will get more info at: [pypi.openrefactory.com](https://pypi.openrefactory.com/)

